### PR TITLE
Fix vulnerability due to outdated moment package

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "soupselect": "0.2.0",
     "htmlparser": "1.7.6",
     "jade": "0.30.0",
-    "moment": "2.0.0",
+    "moment": ">= 2.19.3",
     "gitio2": "2.0.0"
   },
 


### PR DESCRIPTION
I've been receiving a few security alerts regarding vulnerabilities in the old version of moment used in this bot (https://nvd.nist.gov/vuln/detail/CVE-2016-4055 and https://nvd.nist.gov/vuln/detail/CVE-2017-18214). Even though this bot has been mostly replaced by GooeyJr, I thought it would still be good to patch these vulnerabilities.